### PR TITLE
Fix contact form email sending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.idea/

--- a/forms/contact.php
+++ b/forms/contact.php
@@ -1,41 +1,25 @@
 <?php
-  /**
-  * Requires the "PHP Email Form" library
-  * The "PHP Email Form" library is available only in the pro version of the template
-  * The library should be uploaded to: vendor/php-email-form/php-email-form.php
-  * For more info and help: https://bootstrapmade.com/php-email-form/
-  */
+// Simple PHP mail() based contact form
 
-  // Replace contact@example.com with your real receiving email address
-  $receiving_email_address = 'rubangeoinfo@gmail.com';
+$receiving_email_address = 'rubangeoinfo@gmail.com';
 
-  if( file_exists($php_email_form = '../assets/vendor/php-email-form/php-email-form.php' )) {
-    include( $php_email_form );
-  } else {
-    die( 'Unable to load the "PHP Email Form" Library!');
-  }
+$name = isset($_POST['name']) ? strip_tags($_POST['name']) : '';
+$email = isset($_POST['email']) ? trim($_POST['email']) : '';
+$subject = isset($_POST['subject']) ? strip_tags($_POST['subject']) : '';
+$message = isset($_POST['message']) ? strip_tags($_POST['message']) : '';
 
-  $contact = new PHP_Email_Form;
-  $contact->ajax = true;
-  
-  $contact->to = $receiving_email_address;
-  $contact->from_name = $_POST['name'];
-  $contact->from_email = $_POST['email'];
-  $contact->subject = $_POST['subject'];
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+  echo 'Invalid email address';
+  exit;
+}
 
-  // Uncomment below code if you want to use SMTP to send emails. You need to enter your correct SMTP credentials
-  /*
-  $contact->smtp = array(
-    'host' => 'example.com',
-    'username' => 'example',
-    'password' => 'pass',
-    'port' => '587'
-  );
-  */
+$headers = "From: {$name} <{$email}>\r\n";
+$headers .= "Reply-To: {$email}\r\n";
+$headers .= "Content-Type: text/plain; charset=utf-8\r\n";
 
-  $contact->add_message( $_POST['name'], 'From');
-  $contact->add_message( $_POST['email'], 'Email');
-  $contact->add_message( $_POST['message'], 'Message', 10);
-
-  echo $contact->send();
+if (mail($receiving_email_address, $subject, $message, $headers)) {
+  echo 'OK';
+} else {
+  echo 'Error sending email.';
+}
 ?>


### PR DESCRIPTION
## Summary
- Simplify contact form backend to use PHP's built-in `mail` function and send submissions to rubangeoinfo@gmail.com
- Ignore development artifacts such as node_modules and IDE files

## Testing
- `php -l forms/contact.php`


------
https://chatgpt.com/codex/tasks/task_e_68a499eb2bf4832ab32e4d12ce39ef25